### PR TITLE
Module refactor and speedup

### DIFF
--- a/lib/Data/ULID.pm
+++ b/lib/Data/ULID.pm
@@ -10,56 +10,52 @@ our @EXPORT_OK = qw/ulid binary_ulid ulid_date ulid_to_uuid uuid_to_ulid/;
 our %EXPORT_TAGS = ( 'all' => \@EXPORT_OK );
 
 use Time::HiRes qw/time/;
-use Math::BigInt lib => 'GMP', upgrade => 'Math::BigFloat';
-use Math::BigFloat;
-use Math::Random::Secure qw/irand/;
-use Encode::Base32::GMP qw/encode_base32 decode_base32/;
+use Math::BigInt try => 'GMP,LTM';
+use Crypt::PRNG qw/random_bytes/;
 use DateTime;
 
-# The first two of these should only be necessary on 32-bit systems.
-use constant BI_2_32 => Math::BigInt->new('4294967296');
-use constant BI_2_48 => Math::BigInt->new('281474976710656');
-use constant BI_2_64 => Math::BigInt->new('18446744073709551616');
+use Config;
+our $CAN_SKIP_BIGINTS = $Config{ivsize} >= 8;
 
+### EXPORTED ULID FUNCTIONS
 
 sub ulid {
-    my ($ts, $rand) = _ulid(shift);
-    return sprintf('%010s%016s', encode_base32(''.$ts), encode_base32(''.$rand));
+    return _encode(_ulid(shift));
 }
 
 sub binary_ulid {
-    my ($ts, $rand) = _ulid(shift);
-    return _pack($ts, $rand);
+    return _pack(_ulid(shift));
 }
 
 sub ulid_date {
     my $ulid = shift;
     die "ulid_date() needs a normal or binary ULID as parameter" unless $ulid;
     my ($ts, $rand) = _ulid($ulid);
-    $ts = _bint($ts);
-    return DateTime->from_epoch(epoch=>$ts / 1000);
+
+    return DateTime->from_epoch(epoch => _unfix_ts($ts));
 }
 
 sub ulid_to_uuid {
     my $ulid = shift or die "Need ULID to convert";
-    my ($ts, $rand) = _ulid($ulid);
-    my $bin = _pack($ts, $rand);
+    my $bin = _pack(_ulid($ulid));
     return _uuid_bin2str($bin)
 }
 
 sub uuid_to_ulid {
     my $uuid = shift or die "Need UUID to convert";
     my $bin_uuid = _uuid_str2bin($uuid);
-    my ($ts, $rand) = _ulid($bin_uuid);
-    return sprintf('%010s%016s', encode_base32(''.$ts), encode_base32(''.$rand));
+    return _encode(_ulid($bin_uuid));
 }
+
+### HELPER FUNCTIONS
 
 sub _uuid_bin2str {
     my $uuid = shift;
-    use bytes;
+
     return $uuid if length($uuid) == 36;
     die "Invalid uuid" unless length $uuid == 16;
     my @offsets = (4, 2, 2, 2, 6);
+
     return join(
         '-',
         map { unpack 'H*', $_ }
@@ -69,66 +65,116 @@ sub _uuid_bin2str {
 
 sub _uuid_str2bin {
     my $uuid = shift;
-    use bytes;
+
     return $uuid if length $uuid == 16;
     $uuid =~ s/-//g;
+
     return pack 'H*', $uuid;
 }
 
 sub _ulid {
     my $arg = shift;
     my $ts;
-    if ($arg && ref $arg && $arg->isa('DateTime')) {
-        $ts = int($arg->hires_epoch * 1000);
-    }
-    elsif ($arg && length($arg) == 16) {
-        return _unpack($arg);
-    }
-    elsif ($arg) {
-        $arg = _normalize($arg);
-        die "Invalid ULID supplied: wrong length" unless length($arg) == 26;
-        my ($ts_part, $rand_part) = ($arg =~ /^(.{10})(.{16})$/);
-        return (decode_base32($ts_part), decode_base32($rand_part));
-    }
-    $ts ||= int(time() * 1000);
-    my $rand = _bigrand();
-    return ($ts, $rand);
-}
 
-sub _normalize {
-    my $s = shift;
-    $s = uc($s);
-    $s =~ s/[^0123456789ABCDEFGHJKMNPQRSTVWXYZ]//g;
-    return $s;
+    if ($arg) {
+        if (ref $arg && $arg->isa('DateTime')) {
+            $ts = $arg->hires_epoch;
+        }
+        elsif (length($arg) == 16) {
+            return _unpack($arg);
+        }
+        else {
+            $arg = _normalize($arg);
+            die "Invalid ULID supplied: wrong length" unless length($arg) == 26;
+            return _decode($arg);
+        }
+    }
+
+    return (_fix_ts($ts || time()), random_bytes(10));
 }
 
 sub _pack {
-    my ($ts, $rand) = @_;
-    $rand = _bint($rand) unless ref $rand && $rand->isa('Math::BigInt');
-    my $t1 = int($ts / 2**16);
-    my $t2 = $ts % 2**16;
-    my $r1 = $rand >> 64;
-    my $r2 = ($rand % BI_2_64) >> 32;
-    my $r3 = $rand % BI_2_32;
-    return pack('NnnNN', $t1, $t2, $r1, $r2, $r3);
+    return join '', @_;
 }
 
 sub _unpack {
-    my ($t1, $t2, $r1, $r2, $r3) = unpack('NnnNN', shift);
-    my $ts = _bint($t1) * 2**16 + $t2;
-    my $rand = _bint($r1) * BI_2_64 + _bint($r2) * BI_2_32 + _bint($r3);
+    my ($ts, $rand) = unpack 'a6a10', shift;
     return ($ts, $rand);
 }
 
-sub _bint { Math::BigInt->new('' . shift) }
+sub _fix_ts {
+    my $ts = shift;
+    $ts .= '000';
 
-sub _bigrand {
-    # 80-bit random bigint.
-    # Note that irand() is not reliable for bounds above 2**32.
-    my $r1 = _bint(irand(2**32));
-    my $r2 = _bint(irand(2**32));
-    my $r3 = _bint(irand(2**16));
-    return ($r1 * BI_2_48) + ($r2 * 2**16) + $r3;
+    $ts =~ s/\.(\d{3}).*$/$1/;
+    if ($CAN_SKIP_BIGINTS) {
+        return pack 'Nn', int($ts / (2 << 15)), $ts % (2 << 15);
+    } else {
+        return substr chr(0) . Math::BigInt->new($ts)->to_bytes, -6;
+    }
+}
+
+sub _unfix_ts {
+    my $ts = shift;
+
+    if ($CAN_SKIP_BIGINTS) {
+        my ($high, $low) = unpack 'Nn', $ts;
+        $ts = $high * (2 << 15) + $low;
+    } else {
+        $ts = Math::BigInt->new->from_bytes($ts);
+    }
+
+    $ts =~ s/(\d{3})$/.$1/;
+    return $ts;
+}
+
+sub _encode {
+    my ($ts, $rand) = @_;
+    return sprintf('%010s%016s', _encode_b32($ts), _encode_b32($rand));
+}
+
+sub _decode {
+    my ($ts, $rand) = map { _decode_b32($_) } unpack 'A10A16', shift;
+    return ($ts, $rand);
+}
+
+### BASE32 ENCODER / DECODER
+
+my $ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+my %ALPHABET_MAP = do {
+    my $num = 0;
+    map { $_ => substr sprintf('0000%b', $num++), -5 } split //, $ALPHABET;
+};
+
+my %ALPHABET_MAP_REVERSE = map { $ALPHABET_MAP{$_} => $_ } keys %ALPHABET_MAP;
+
+sub _normalize {
+    my $s = uc(shift);
+    my $re = "[^$ALPHABET]";
+
+    $s =~ s/$re//g;
+    return $s;
+}
+
+sub _zero_pad {
+    my ($value, $mul) = @_;
+    $value =~ s/^0+//;
+    my $left = $mul - length($value) % $mul;
+    return '0' x ($left % $mul) . $value;
+}
+
+sub _encode_b32 {
+    my $bits = unpack 'B*', shift;
+    $bits = _zero_pad($bits, 5);
+    $bits =~ s/(.{5})/$ALPHABET_MAP_REVERSE{$1}/eg;
+    return $bits;
+}
+
+sub _decode_b32 {
+    my $encoded = shift;
+    $encoded =~ s/(.)/$ALPHABET_MAP{$1}/egi;
+    return pack 'B*', _zero_pad($encoded, 8);
 }
 
 1;

--- a/lib/Data/ULID.pm
+++ b/lib/Data/ULID.pm
@@ -105,12 +105,13 @@ sub _unpack {
 
 sub _fix_ts {
     my $ts = shift;
-    $ts .= '000';
 
-    $ts =~ s/\.(\d{3}).*$/$1/;
     if ($CAN_SKIP_BIGINTS) {
+        $ts *= 1000;
         return pack 'Nn', int($ts / (2 << 15)), $ts % (2 << 15);
     } else {
+        $ts .= '000';
+        $ts =~ s/\.(\d{3}).*$/$1/;
         return Math::BigInt->new($ts)->to_bytes;
     }
 }
@@ -120,13 +121,12 @@ sub _unfix_ts {
 
     if ($CAN_SKIP_BIGINTS) {
         my ($high, $low) = unpack 'Nn', $ts;
-        $ts = $high * (2 << 15) + $low;
+        return ($high * (2 << 15) + $low) / 1000;
     } else {
         $ts = Math::BigInt->from_bytes($ts);
+        $ts =~ s/(\d{3})$/.$1/;
+        return $ts;
     }
-
-    $ts =~ s/(\d{3})$/.$1/;
-    return $ts;
 }
 
 sub _encode {

--- a/lib/Data/ULID.pm
+++ b/lib/Data/ULID.pm
@@ -10,7 +10,7 @@ our @EXPORT_OK = qw/ulid binary_ulid ulid_date ulid_to_uuid uuid_to_ulid/;
 our %EXPORT_TAGS = ( 'all' => \@EXPORT_OK );
 
 use Time::HiRes qw/time/;
-use Math::BigInt try => 'GMP,LTM';
+use Math::BigInt 1.999808 try => 'GMP,LTM';
 use Crypt::PRNG qw/random_bytes/;
 use DateTime;
 

--- a/lib/Data/ULID.pm
+++ b/lib/Data/ULID.pm
@@ -142,7 +142,9 @@ sub _decode {
 sub _zero_pad {
     my ($value, $mul, $char) = @_;
     $char ||= '0';
-    $value =~ s/^$char+//;
+
+    while ($char eq substr $value, 0, 1) { substr $value, 0, 1, '' }
+
     my $left = $mul - length($value) % $mul;
     return $char x ($left % $mul) . $value;
 }

--- a/lib/Data/ULID.pm
+++ b/lib/Data/ULID.pm
@@ -169,13 +169,16 @@ sub _normalize {
 sub _encode_b32 {
     my $bits = unpack 'B*', shift;
     $bits = _zero_pad($bits, 5);
-    $bits =~ s/(.{5})/$ALPHABET_MAP_REVERSE{$1}/eg;
-    return $bits;
+
+    my $result = '';
+    for (my $i = 0; $i < length $bits; $i += 5) {
+        $result .= $ALPHABET_MAP_REVERSE{substr $bits, $i, 5};
+    }
+    return $result;
 }
 
 sub _decode_b32 {
-    my $encoded = shift;
-    $encoded =~ s/(.)/$ALPHABET_MAP{$1}/egi;
+    my $encoded = join '', map { $ALPHABET_MAP{uc $_} } split //, shift;
     return pack 'B*', _zero_pad($encoded, 8);
 }
 

--- a/t/00_basic.t
+++ b/t/00_basic.t
@@ -9,6 +9,8 @@ use Test::More;
 use_ok('Data::ULID', qw/ulid binary_ulid ulid_date uuid_to_ulid ulid_to_uuid/);
 
 my $b32_re = qr/^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]*$/;
+my $small_ulid = '00000000010000000000000001';
+my $small_ulid_bin = "\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01";
 my $old_ulid = '01B3Z3A7GQ6627FZPDQHQP87PM';
 my $old_ulid_bin = "\x01\x58\xfe\x35\x1e\x17\x31\x84\x77\xfe\xcd\xbc\x6f\x64\x1e\xd4";
 my $fixed_t = 1481797018.267;
@@ -31,6 +33,9 @@ my $b_ulid = binary_ulid($ulid);
 
 is(length($b_ulid), 16,
    "Length of binary ULID is 16");
+if (length($b_ulid) != 16) {
+    use Data::Dumper; die Dumper(unpack 'H*', $b_ulid);
+}
 
 my $ulid2 = ulid($b_ulid);
 
@@ -76,5 +81,10 @@ ok(ulid_to_uuid($old_ulid) eq $uuid_from_old_ulid,
 
 ok(uuid_to_ulid($uuid_from_old_ulid) eq $old_ulid,
    "Back-and-forth UUID<=>ULID conversion works");
+
+is ulid($small_ulid_bin), $small_ulid, 'small ulid conversion ok';
+is ulid($small_ulid), $small_ulid, 'small ulid conversion ok';
+is unpack('H*', binary_ulid($small_ulid)), unpack('H*', $small_ulid_bin), 'small binary ulid conversion ok';
+is binary_ulid($small_ulid_bin), $small_ulid_bin, 'small binary ulid conversion ok';
 
 done_testing;

--- a/t/00_basic.t
+++ b/t/00_basic.t
@@ -1,7 +1,10 @@
 #!/usr/bin/env perl
 
+use strict;
+use warnings;
+
 use DateTime;
-use Test::More tests => 15;
+use Test::More;
 
 use_ok('Data::ULID', qw/ulid binary_ulid ulid_date uuid_to_ulid ulid_to_uuid/);
 
@@ -16,60 +19,68 @@ my $ulid_from_uuid_v1 = '1MS94QZJ8527KB52ZTJF6FQNTH';
 my $ulid_from_uuid_v5 = '1SHSS83BCTBH8BSC7SQ56T1BNV';
 my $uuid_from_old_ulid = '0158fe35-1e17-3184-77fe-cdbc6f641ed4';
 
-my $ulid = ulid();
+for (0 .. 1) {
+    subtest "testing for CAN_SKIP_BIGINTS = $_" => sub {
+        local $Data::ULID::CAN_SKIP_BIGINTS = $_;
 
-ok(length($ulid) == 26,
-   "Length of canonical ULID is 26");
+        my $ulid = ulid();
 
-ok($ulid =~ $b32_re,
-   "ULID is valid base32 (Crockford variant)");
+        ok(length($ulid) == 26,
+           "Length of canonical ULID is 26");
 
-my $b_ulid = binary_ulid($ulid);
+        ok($ulid =~ $b32_re,
+           "ULID is valid base32 (Crockford variant)");
 
-ok(length($b_ulid) == 16,
-   "Length of binary ULID is 16");
+        my $b_ulid = binary_ulid($ulid);
 
-my $ulid2 = ulid($b_ulid);
+        is(length($b_ulid), 16,
+           "Length of binary ULID is 16");
 
-ok($ulid eq $ulid2,
-   "Converting back from binary yields same string");
+        my $ulid2 = ulid($b_ulid);
 
-my $dt = ulid_date($ulid);
+        is($ulid, $ulid2,
+           "Converting back from binary yields same string");
 
-ok($dt->isa("DateTime"),
-   "ulid_date() yields DateTime");
+        my $dt = ulid_date($ulid);
 
-my $b_dt = ulid_date($b_ulid);
+        ok($dt->isa("DateTime"),
+           "ulid_date() yields DateTime");
 
-ok("$dt" eq "$b_dt",
-   "Canonical and binary ULID yield same DateTime");
+        my $b_dt = ulid_date($b_ulid);
 
-my $o_dt = ulid_date($old_ulid);
+        ok("$dt" eq "$b_dt",
+           "Canonical and binary ULID yield same DateTime");
 
-ok($o_dt->hires_epoch == 1481733643.799,
-   "Old ULID timestamp has correct hires_epoch");
+        my $o_dt = ulid_date($old_ulid);
 
-my $ob_ulid = binary_ulid($old_ulid);
+        is($o_dt->hires_epoch, 1481733643.799,
+           "Old ULID timestamp has correct hires_epoch");
 
-ok($ob_ulid eq $old_ulid_bin,
-   "Binary old ULID is correct");
+        my $ob_ulid = binary_ulid($old_ulid);
 
-my $f_ulid = ulid($fixed_dt);
+        ok($ob_ulid eq $old_ulid_bin,
+           "Binary old ULID is correct");
 
-ok(substr($f_ulid, 0, 10) eq '01B40ZR8MV',
-   "ULID from fixed DateTime works as expected");
+        my $f_ulid = ulid($fixed_dt);
 
-ok(ulid_date($f_ulid)->hires_epoch == $fixed_t,
-   "ULID from fixed DateTime has correct hires_epoch");
+        ok(substr($f_ulid, 0, 10) eq '01B40ZR8MV',
+           "ULID from fixed DateTime works as expected");
 
-ok(uuid_to_ulid($uuid_str_v1) eq $ulid_from_uuid_v1,
-   "UUID v1 converts to ULID as expected");
+        ok(ulid_date($f_ulid)->hires_epoch == $fixed_t,
+           "ULID from fixed DateTime has correct hires_epoch");
 
-ok(uuid_to_ulid($uuid_str_v5) eq $ulid_from_uuid_v5,
-   "UUID v5 converts to ULID as expected");
+        ok(uuid_to_ulid($uuid_str_v1) eq $ulid_from_uuid_v1,
+           "UUID v1 converts to ULID as expected");
 
-ok(ulid_to_uuid($old_ulid) eq $uuid_from_old_ulid,
-   "ULID converts to expected UUID");
+        ok(uuid_to_ulid($uuid_str_v5) eq $ulid_from_uuid_v5,
+           "UUID v5 converts to ULID as expected");
 
-ok(uuid_to_ulid($uuid_from_old_ulid) eq $old_ulid,
-   "Back-and-forth UUID<=>ULID conversion works");
+        ok(ulid_to_uuid($old_ulid) eq $uuid_from_old_ulid,
+           "ULID converts to expected UUID");
+
+        ok(uuid_to_ulid($uuid_from_old_ulid) eq $old_ulid,
+           "Back-and-forth UUID<=>ULID conversion works");
+    };
+}
+
+done_testing;

--- a/t/00_basic.t
+++ b/t/00_basic.t
@@ -19,68 +19,62 @@ my $ulid_from_uuid_v1 = '1MS94QZJ8527KB52ZTJF6FQNTH';
 my $ulid_from_uuid_v5 = '1SHSS83BCTBH8BSC7SQ56T1BNV';
 my $uuid_from_old_ulid = '0158fe35-1e17-3184-77fe-cdbc6f641ed4';
 
-for (0 .. 1) {
-    subtest "testing for CAN_SKIP_BIGINTS = $_" => sub {
-        local $Data::ULID::CAN_SKIP_BIGINTS = $_;
+my $ulid = ulid();
 
-        my $ulid = ulid();
+ok(length($ulid) == 26,
+   "Length of canonical ULID is 26");
 
-        ok(length($ulid) == 26,
-           "Length of canonical ULID is 26");
+ok($ulid =~ $b32_re,
+   "ULID is valid base32 (Crockford variant)");
 
-        ok($ulid =~ $b32_re,
-           "ULID is valid base32 (Crockford variant)");
+my $b_ulid = binary_ulid($ulid);
 
-        my $b_ulid = binary_ulid($ulid);
+is(length($b_ulid), 16,
+   "Length of binary ULID is 16");
 
-        is(length($b_ulid), 16,
-           "Length of binary ULID is 16");
+my $ulid2 = ulid($b_ulid);
 
-        my $ulid2 = ulid($b_ulid);
+is($ulid, $ulid2,
+   "Converting back from binary yields same string");
 
-        is($ulid, $ulid2,
-           "Converting back from binary yields same string");
+my $dt = ulid_date($ulid);
 
-        my $dt = ulid_date($ulid);
+ok($dt->isa("DateTime"),
+   "ulid_date() yields DateTime");
 
-        ok($dt->isa("DateTime"),
-           "ulid_date() yields DateTime");
+my $b_dt = ulid_date($b_ulid);
 
-        my $b_dt = ulid_date($b_ulid);
+ok("$dt" eq "$b_dt",
+   "Canonical and binary ULID yield same DateTime");
 
-        ok("$dt" eq "$b_dt",
-           "Canonical and binary ULID yield same DateTime");
+my $o_dt = ulid_date($old_ulid);
 
-        my $o_dt = ulid_date($old_ulid);
+is($o_dt->hires_epoch, 1481733643.799,
+   "Old ULID timestamp has correct hires_epoch");
 
-        is($o_dt->hires_epoch, 1481733643.799,
-           "Old ULID timestamp has correct hires_epoch");
+my $ob_ulid = binary_ulid($old_ulid);
 
-        my $ob_ulid = binary_ulid($old_ulid);
+ok($ob_ulid eq $old_ulid_bin,
+   "Binary old ULID is correct");
 
-        ok($ob_ulid eq $old_ulid_bin,
-           "Binary old ULID is correct");
+my $f_ulid = ulid($fixed_dt);
 
-        my $f_ulid = ulid($fixed_dt);
+ok(substr($f_ulid, 0, 10) eq '01B40ZR8MV',
+   "ULID from fixed DateTime works as expected");
 
-        ok(substr($f_ulid, 0, 10) eq '01B40ZR8MV',
-           "ULID from fixed DateTime works as expected");
+ok(ulid_date($f_ulid)->hires_epoch == $fixed_t,
+   "ULID from fixed DateTime has correct hires_epoch");
 
-        ok(ulid_date($f_ulid)->hires_epoch == $fixed_t,
-           "ULID from fixed DateTime has correct hires_epoch");
+ok(uuid_to_ulid($uuid_str_v1) eq $ulid_from_uuid_v1,
+   "UUID v1 converts to ULID as expected");
 
-        ok(uuid_to_ulid($uuid_str_v1) eq $ulid_from_uuid_v1,
-           "UUID v1 converts to ULID as expected");
+ok(uuid_to_ulid($uuid_str_v5) eq $ulid_from_uuid_v5,
+   "UUID v5 converts to ULID as expected");
 
-        ok(uuid_to_ulid($uuid_str_v5) eq $ulid_from_uuid_v5,
-           "UUID v5 converts to ULID as expected");
+ok(ulid_to_uuid($old_ulid) eq $uuid_from_old_ulid,
+   "ULID converts to expected UUID");
 
-        ok(ulid_to_uuid($old_ulid) eq $uuid_from_old_ulid,
-           "ULID converts to expected UUID");
-
-        ok(uuid_to_ulid($uuid_from_old_ulid) eq $old_ulid,
-           "Back-and-forth UUID<=>ULID conversion works");
-    };
-}
+ok(uuid_to_ulid($uuid_from_old_ulid) eq $old_ulid,
+   "Back-and-forth UUID<=>ULID conversion works");
 
 done_testing;


### PR DESCRIPTION
Hello there!

This PR focuses on making the module faster by refactoring some of its parts. The core of the code layout stays the same, but various parts are refactored to allow for much higher generation speeds (64 bit installation):
```
              Rate old (text) new (text)
old (text) 13036/s         --       -82%
new (text) 73702/s       465%         --

                 Rate old (binary) new (binary)
old (binary)   8597/s           --         -97%
new (binary) 303842/s        3434%           --

```

On 32 bit the speedup will be much smaller (~150% text), but should work without problems. I took extra care not to overflow any 32 bit integers in the code.

Main changes:
- got rid of Math::Random::Secure dependency and used CryptX (Crypt::PRNG) instead
- got rid of Encode::Base32::GMP dependency and replaced it with custom encoding / decoding code
- got rid of many Math::BigInt object creations and stringifications, but left the dependency for 32 bit compatibility
- to know whether we need to construct BigInts at all, we look into perl IV size and see if it is 64 bit (or more)
- previously performed math operations are now mostly replaced by string operations and packing / unpacking
- no longer requires GMP, but will try to load it anyway. If it doesn't, then CryptX has LTM, which we try to load in the second place

Reasoning behind performance changes:
- what was previously kept as a Math::BigInt object is now kept as a bytestring. We no longer need to construct those objects
- before base32 encoding, BigInt objects were stringified and then loaded into Math::GMPz (inside the encoder). We no longer need to stringify and construct anew, since built in encoder now works on bytestrings
- random_bytes from CryptX is very fast and immediately delivers the entropy we need (no need to calculate it from BigInts)
- all is kept as bytestring internally, even the timestamp. We only need Math::BigInt to convert 48 bit timestamp back and forth from base10 to a bytestring on 32 bit systems. On 64 bit systems we can just pack and unpack it from `Nn` as before
- base32 encoder / decoder is extremely fast because it utilizes substitution on bitstrings and packing. In my tests, its speed seems to be on par with Encode::Base32::GMP

The big CON I see is that it now requires CryptX, which is quite big and needs a compiler. That being said, even now the library requires compiler because of GMP.

It passes all the tests unchanged, however I added a little refactor there as well that helped me get things right.

Lastly, I've seen that you haven't uploaded anything to CPAN in quite some time. I'm willing to take over maintenance of the module if it isn't something that you can or want to spend time on these days - just let me know.