### PR TITLE
Module maintenace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.{pl,pm,t,pod}]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true

--- a/Changes
+++ b/Changes
@@ -1,0 +1,26 @@
+1.1.2
+    - Fix POD (version history)
+
+1.1.1
+    - Fix module version number
+
+1.1.0
+    - Speedups courtesy of Bartosz Jarzyna (brtastic on CPAN, bbrtj on Github)
+    - Use Crypt::PRNG for random number generation
+
+1.0.0
+    - UUID conversion support; semantic versioning
+
+0.4
+    - Bugfix: 'Invalid argument supplied to Math::GMPz::overload_mod' for older versions of Math::GMPz on Windows and FreeBSD
+    - Podfix
+
+0.3
+    - Bugfix: Try to prevent 'Inappropriate argument' error from pre-0.43 versions of Math::GMPz
+
+0.2
+    - Bugfixes: (a) fix errors on Perl 5.18 and older, (b) address an issue with GMPz wrt Math::BigInt objects
+
+0.1
+    - Initial version
+

--- a/README.md
+++ b/README.md
@@ -137,17 +137,3 @@ Baldur Kristinsson, December 2016
 This is free software. It may be copied, distributed and modified under the
 same terms as Perl itself.
 
-# VERSION HISTORY
-
-    0.1   - Initial version.
-    0.2   - Bugfixes: (a) fix errors on Perl 5.18 and older, (b) address an issue
-            with GMPz wrt Math::BigInt objects.
-    0.3   - Bugfix: Try to prevent 'Inappropriate argument' error from pre-0.43
-            versions of Math::GMPz.
-    0.4   - Bugfix: 'Invalid argument supplied to Math::GMPz::overload_mod' for
-            older versions of Math::GMPz on Windows and FreeBSD. Podfix.
-    1.0.0 - UUID conversion support; semantic versioning.
-    1.1.0 - Speedups courtesy of Bartosz Jarzyna (brtastic on CPAN, bbrtj on
-            Github). Use Crypt::PRNG for random number generation.
-    1.1.1 - Fix module version number.
-    1.1.2 - Fix POD (version history).

--- a/README.md
+++ b/README.md
@@ -124,10 +124,6 @@ similarly wrong. Such UUIDs should only be used in contexts where no checking
 of these fields will be performed and no attempt will be made to extract or
 validate non-random information (i.e. timestamp, MAC address or namespace).
 
-# DEPENDENCIES
-
-[Math::Random::Secure](https://metacpan.org/pod/Math::Random::Secure), [Encode::Base32::GMP](https://metacpan.org/pod/Encode::Base32::GMP).
-
 # AUTHOR
 
 Baldur Kristinsson, December 2016

--- a/lib/Data/ULID.pm
+++ b/lib/Data/ULID.pm
@@ -364,20 +364,5 @@ Baldur Kristinsson, December 2016
 This is free software. It may be copied, distributed and modified under the
 same terms as Perl itself.
 
-
-=head1 VERSION HISTORY
-
- 0.1   - Initial version.
- 0.2   - Bugfixes: (a) fix errors on Perl 5.18 and older, (b) address an issue
-         with GMPz wrt Math::BigInt objects.
- 0.3   - Bugfix: Try to prevent 'Inappropriate argument' error from pre-0.43
-         versions of Math::GMPz.
- 0.4   - Bugfix: 'Invalid argument supplied to Math::GMPz::overload_mod' for
-         older versions of Math::GMPz on Windows and FreeBSD. Podfix.
- 1.0.0 - UUID conversion support; semantic versioning.
- 1.1.0 - Speedups courtesy of Bartosz Jarzyna (brtastic on CPAN, bbrtj on
-         Github). Use Crypt::PRNG for random number generation.
- 1.1.1 - Fix module version number.
- 1.1.2 - Fix POD (version history).
-
 =cut
+

--- a/lib/Data/ULID.pm
+++ b/lib/Data/ULID.pm
@@ -349,11 +349,6 @@ validate non-random information (i.e. timestamp, MAC address or namespace).
 =back
 
 
-=head1 DEPENDENCIES
-
-L<Math::Random::Secure>, L<Encode::Base32::GMP>.
-
-
 =head1 AUTHOR
 
 Baldur Kristinsson, December 2016


### PR DESCRIPTION
This set of changes aims to improve overall module quality.

- `.editorconfig` will help contributors and their editors
- `Changes` will make metacpan show latest changes on the module page
- old dependency list was removed from docs
- `CAN_SKIP_BIGINTS` module variable was transformed to a constant, resolved at compile time
- Math::BigInt is only loaded if we actually need it