### PR TITLE
Replace CryptX with Bytes::Random::Secure::Tiny

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,6 @@ version = 1.2.1
 repository = http://github.com/bk/Data-ULID
 
 [Prereqs]
-CryptX = 0
+Bytes::Random::Secure::Tiny = 0
 Time::HiRes = 0
 

--- a/lib/Data/ULID.pm
+++ b/lib/Data/ULID.pm
@@ -10,7 +10,9 @@ our @EXPORT_OK = qw/ulid binary_ulid ulid_date ulid_to_uuid uuid_to_ulid/;
 our %EXPORT_TAGS = ( 'all' => \@EXPORT_OK );
 
 use Time::HiRes qw/time/;
-use Crypt::PRNG qw/random_bytes/;
+
+use Bytes::Random::Secure::Tiny;
+my $rng = Bytes::Random::Secure::Tiny->new;
 
 use constant HAS_DATETIME => eval { require DateTime; 1 };
 
@@ -101,7 +103,7 @@ sub _ulid {
         }
     }
 
-    return (_fix_ts($ts || time()), random_bytes(10));
+    return (_fix_ts($ts || time()), $rng->bytes(10));
 }
 
 sub _pack {


### PR DESCRIPTION
I'd like to suggest replacing CryptX with a pure-perl solution.
Currently, CryptX is only needed for fast and secure random bytes generator. It's great for that, but it contains a bunch of other stuff we don't need. It also requires a compiler, which may be a deal breaker in some cases.

By replacing it with Bytes::Random::Secure::Tiny we:
- retain the current functionality
- take a performance hit for ULID generation (about 40% slower)
- get rid of the need for a compiler

I think performance is no longer a concern since I wrote Data::ULID::XS and it's much faster for ULID generation anyway, so would be a primary choice in high-speed scenarios.

Historically, Data::ULID always required a compiler - it used Encode::Base32::GMP before it used CryptX. Bytes::Random::Secure::Tiny seems to be a solid choice, has no dependencies and is used by Crypt::Perl.